### PR TITLE
Added Zip operation and Sample operation

### DIFF
--- a/examples/filter_even.cpp
+++ b/examples/filter_even.cpp
@@ -2,7 +2,7 @@
 
 #include "filter_rdd.h"
 #include "generator_rdd.h"
-
+#include "sample_rdd.h"
 template <cpark::concepts::Rdd R>
 void printRdd(R rdd) {
   for (const cpark::concepts::Split auto& split : rdd) {
@@ -35,8 +35,12 @@ int main() {
   printRdd(filter_rdd_1);
 
   std::cout<< "Sample rdd: " <<std::endl;
-  auto sample_rdd = FilterRdd(generator_rdd, sample);
+  auto sample_rdd = FilterRdd(generator_rdd, sampleFunction);
   printRdd(sample_rdd);
+
+  std::cout<< "Sample rdd 2: " <<std::endl;
+  auto sample_rdd2 = SampleRdd(generator_rdd, 0.1);
+  printRdd(sample_rdd2);
   
   // Test for pipeline and Filter(Func func) operators
   std::cout << "Filter rdd (operators): " << std::endl;

--- a/examples/filter_even.cpp
+++ b/examples/filter_even.cpp
@@ -34,6 +34,10 @@ int main() {
   auto filter_rdd_1 = FilterRdd(generator_rdd, even);
   printRdd(filter_rdd_1);
 
+  std::cout<< "Sample rdd: " <<std::endl;
+  auto sample_rdd = FilterRdd(generator_rdd, sample);
+  printRdd(sample_rdd);
+  
   // Test for pipeline and Filter(Func func) operators
   std::cout << "Filter rdd (operators): " << std::endl;
   auto filter_rdd_2 = generator_rdd | Filter(even);

--- a/examples/filter_even.cpp
+++ b/examples/filter_even.cpp
@@ -29,23 +29,25 @@ int main() {
     return 0 == i % 2;
   };
 
-  // Test for FilterRdd(const R1& prev, Func func) constructor
+  // Test for FilterRdd(const R& prev, Func func) constructor
   std::cout << "Filter rdd (basic): " << std::endl;
   auto filter_rdd_1 = FilterRdd(generator_rdd, even);
   printRdd(filter_rdd_1);
 
-  std::cout<< "Sample rdd: " <<std::endl;
-  auto sample_rdd = FilterRdd(generator_rdd, sampleFunction);
-  printRdd(sample_rdd);
-
-  std::cout<< "Sample rdd 2: " <<std::endl;
-  auto sample_rdd2 = SampleRdd(generator_rdd, 0.1);
-  printRdd(sample_rdd2);
-  
   // Test for pipeline and Filter(Func func) operators
   std::cout << "Filter rdd (operators): " << std::endl;
   auto filter_rdd_2 = generator_rdd | Filter(even);
   printRdd(filter_rdd_2);
+
+  // Creates a sample rdd with sample ratio of 0.5 using class constructor style
+  std::cout << "Sample rdd: " << std::endl;
+  auto sample_rdd = SampleRdd(generator_rdd, 0.5);
+  printRdd(sample_rdd);
+
+  // Creates a sample rdd with sample ratio of 0.5 using pipeline style
+  std::cout << "Sample rdd (operators): " << std::endl;
+  auto sample_rdd_2 = generator_rdd | Sample(0.5);
+  printRdd(sample_rdd_2);
 
   return 0;
 }

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -64,20 +64,11 @@ int main() {
   }
   std::cout << std::endl;
 
- 
   // Creates a transformed rdd which adds a " world" string to the elements in the generator rdd.
   auto transformed_rdd = TransformedRdd(generator_rdd, [](const auto& x) { return x + " world"; });
   std::cout << "The elements in the fourth split of transformed rdd are: ";
   for (const auto& x : transformed_rdd[3]) {
     std::cout << x << ", ";
-  }
-  std::cout << std::endl;
-
-   // Creates a zipped rdd.
-  auto zipped_rdd = ZippedRdd(generator_rdd, transformed_rdd);
-  std::cout << "The elements in the first split of zipped rdd are: ";
-  for (const auto& x : zipped_rdd[0]) {
-    std::cout << "(" << x.first << ", " << x.second << ")" << ", ";
   }
   std::cout << std::endl;
 
@@ -92,4 +83,13 @@ int main() {
   // Calculate the sum of the plain rdd by reduce.
   int res = plain_rdd | Reduce([](int x, int y) { return x + y; });
   std::cout << "The sum of the plain rdd is " << res << std::endl;
+
+  // Creates a zipped rdd.
+  auto zipped_rdd = ZippedRdd(generator_rdd, transformed_rdd);
+  std::cout << "The elements in the first split of zipped rdd are: ";
+  for (const auto& x : zipped_rdd[0]) {
+    std::cout << "(" << x.first << ", " << x.second << ")"
+              << ", ";
+  }
+  std::cout << std::endl;
 }

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -6,7 +6,7 @@
 #include "plain_rdd.h"
 #include "reduce.h"
 #include "transformed_rdd.h"
-
+#include "zipped_rdd.h"
 int main() {
   using namespace cpark;
 
@@ -64,11 +64,20 @@ int main() {
   }
   std::cout << std::endl;
 
+ 
   // Creates a transformed rdd which adds a " world" string to the elements in the generator rdd.
   auto transformed_rdd = TransformedRdd(generator_rdd, [](const auto& x) { return x + " world"; });
   std::cout << "The elements in the fourth split of transformed rdd are: ";
   for (const auto& x : transformed_rdd[3]) {
     std::cout << x << ", ";
+  }
+  std::cout << std::endl;
+
+   // Creates a zipped rdd.
+  auto zipped_rdd = ZippedRdd(generator_rdd, transformed_rdd);
+  std::cout << "The elements in the fourth split of zipped rdd are: ";
+  for (const auto& x : zipped_rdd[3]) {
+    std::cout << x.first << ", ";
   }
   std::cout << std::endl;
 

--- a/examples/simple.cpp
+++ b/examples/simple.cpp
@@ -75,9 +75,9 @@ int main() {
 
    // Creates a zipped rdd.
   auto zipped_rdd = ZippedRdd(generator_rdd, transformed_rdd);
-  std::cout << "The elements in the fourth split of zipped rdd are: ";
-  for (const auto& x : zipped_rdd[3]) {
-    std::cout << x.first << ", ";
+  std::cout << "The elements in the first split of zipped rdd are: ";
+  for (const auto& x : zipped_rdd[0]) {
+    std::cout << "(" << x.first << ", " << x.second << ")" << ", ";
   }
   std::cout << std::endl;
 

--- a/include/filter_rdd.h
+++ b/include/filter_rdd.h
@@ -2,7 +2,6 @@
 #define CPARK_FILTER_RDD_H
 
 #include <vector>
-#include <random>
 #include "base_rdd.h"
 #include "utils.h"
 
@@ -185,7 +184,7 @@ auto operator|(const R& r, const Filter<Func>& filter) {
  * Get all the even numbers from 0 to 50.
  */
 
-/** @} */ // end of t_Filter
+/** @} */  // end of t_Filter
 
 }  // namespace cpark
 

--- a/include/filter_rdd.h
+++ b/include/filter_rdd.h
@@ -2,7 +2,7 @@
 #define CPARK_FILTER_RDD_H
 
 #include <vector>
-
+#include <random>
 #include "base_rdd.h"
 #include "utils.h"
 

--- a/include/sample_rdd.h
+++ b/include/sample_rdd.h
@@ -1,45 +1,49 @@
-
-
 #ifndef CPARK_SAMPLE_RDD_H
 #define CPARK_SAMPLE_RDD_H
 
-#include <iostream>
 #include <random>
+#include <vector>
+#include "base_rdd.h"
 #include "filter_rdd.h"
-#include "generator_rdd.h"
-
-
+#include "utils.h"
 namespace cpark {
 
+/**
+ * An Rdd holding the sampled data from an old rdd by a specific sample fraction
+ * @tparam R Type of the old Rdd.
+ * The type of the old Rdd `R`'s elements should be able to invoke random boolean function,
+ * the invoke result must be in boolean, and the element type shouldn't change after sampling.
+ */
 template <concepts::Rdd R>
-class SampleRdd : public BaseRdd<SampleRdd<R>>{
+requires std::invocable<std::function<bool(int)>, utils::RddElementType<R>>&& std::is_convertible_v<
+    std::invoke_result_t<std::function<bool(int)>, utils::RddElementType<R>>, bool> class SampleRdd
+    : public BaseRdd<SampleRdd<R>> {
 public:
-    using Base = BaseRdd<SampleRdd<R>>;
-    friend Base;
+  using Base = BaseRdd<SampleRdd<R>>;
+  friend Base;
 
-    SampleRdd(const R& prev, double probability) : Base{prev, false}, probability_{probability} {
-   
-    auto sample = [](int i){
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::bernoulli_distribution d(0.1);
-            return d(gen);
-        };
+public:
+  /**
+   * Main constructor of SampleRdd.
+   * @param prev Reference to previous Rdd of type R
+   * @param fraction The desired sampling ratio from the 'prev' RDD
+   */
+  constexpr SampleRdd(const R& prev, double fraction) : Base{prev, false}, fraction_{fraction} {
+    static_assert(concepts::Rdd<SampleRdd<R>>,
+                  "Instance of SampleRdd does not satisfy Rdd concept.");
+    // Create the sampled splits.
+    for (const concepts::Split auto& prev_split : prev) {
+      splits_.emplace_back(FilterView(prev_split, func), prev_split);
+      splits_.back().addDependency(prev_split);
+    }
+  };
 
-    std::function<bool(int)> sampleFunction = sample;
-
-    FilterRdd<R, std::function<bool(int)>> filter_rdd = FilterRdd(prev, sampleFunction);
-
-    for (const concepts::Split auto& prev_split : filter_rdd) {
-        splits_.emplace_back(prev_split, prev_split);
-        splits_.back().addDependency(prev_split);
-       
-        }
-
-    };
-
-    constexpr SampleRdd(const SampleRdd&) = default;
-    SampleRdd& operator=(const SampleRdd&) = default;
+  // Explicitly define default copy constrictor and assignment operator,
+  // because some linters or compilers can not define implicit copy constructors for this class,
+  // though they are supposed to do so.
+  // TODO: find out why.
+  constexpr SampleRdd(const SampleRdd&) = default;
+  SampleRdd& operator=(const SampleRdd&) = default;
 
 private:
   constexpr auto beginImpl() const { return std::ranges::begin(splits_); }
@@ -47,14 +51,42 @@ private:
   constexpr auto endImpl() const { return std::ranges::end(splits_); }
 
 private:
-    using SampleViewType = std::ranges::range_value_t<R>;
-    std::vector<ViewSplit<SampleViewType>> splits_{};
-    double probability_;
-
+  double fraction_;
+  std::function<bool(int)> func = [this](int i) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::bernoulli_distribution d(fraction_);
+    return d(gen);
+  };
+  std::vector<ViewSplit<FilterView<std::ranges::range_value_t<R>, std::function<bool(int)>>>>
+      splits_{};
 };
+
+/**
+ * Helper class to create Sample Rdd with pipeline operator `|`.
+ */
+class Sample {
+public:
+  explicit Sample(double fraction) : fraction_{fraction} {}
+  template <concepts::Rdd R, typename T = utils::RddElementType<R>>
+  requires std::invocable<std::function<bool(int)>, T>&&
+      std::is_same_v<std::invoke_result_t<std::function<bool(int)>, T>, bool> auto
+      operator()(const R& r) const {
+    return SampleRdd(r, fraction_);
+  }
+
+private:
+  double fraction_;
+};
+
+/**
+ * Helper function to create Sample Rdd with pipeline operator `|`.
+ */
+template <concepts::Rdd R>
+auto operator|(const R& r, const Sample& sample) {
+  return sample(r);
+}
 
 }  // namespace cpark
 
-#endif  // CPARK_SAMPLE_RDD_H
-
-
+#endif  //CPARK_SAMPLE_RDD_H

--- a/include/sample_rdd.h
+++ b/include/sample_rdd.h
@@ -96,6 +96,7 @@ auto operator|(const R& r, const Sample& sample) {
   return sample(r);
 }
 
+/** @} */ // end of t_Sample
 }  // namespace cpark
 
 #endif  //CPARK_SAMPLE_RDD_H

--- a/include/sample_rdd.h
+++ b/include/sample_rdd.h
@@ -1,0 +1,60 @@
+
+
+#ifndef CPARK_SAMPLE_RDD_H
+#define CPARK_SAMPLE_RDD_H
+
+#include <iostream>
+#include <random>
+#include "filter_rdd.h"
+#include "generator_rdd.h"
+
+
+namespace cpark {
+
+template <concepts::Rdd R>
+class SampleRdd : public BaseRdd<SampleRdd<R>>{
+public:
+    using Base = BaseRdd<SampleRdd<R>>;
+    friend Base;
+
+    SampleRdd(const R& prev, double probability) : Base{prev, false}, probability_{probability} {
+   
+    auto sample = [](int i){
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::bernoulli_distribution d(0.1);
+            return d(gen);
+        };
+
+    std::function<bool(int)> sampleFunction = sample;
+
+    FilterRdd<R, std::function<bool(int)>> filter_rdd = FilterRdd(prev, sampleFunction);
+
+    for (const concepts::Split auto& prev_split : filter_rdd) {
+        splits_.emplace_back(prev_split, prev_split);
+        splits_.back().addDependency(prev_split);
+       
+        }
+
+    };
+
+    constexpr SampleRdd(const SampleRdd&) = default;
+    SampleRdd& operator=(const SampleRdd&) = default;
+
+private:
+  constexpr auto beginImpl() const { return std::ranges::begin(splits_); }
+
+  constexpr auto endImpl() const { return std::ranges::end(splits_); }
+
+private:
+    using SampleViewType = std::ranges::range_value_t<R>;
+    std::vector<ViewSplit<SampleViewType>> splits_{};
+    double probability_;
+
+};
+
+}  // namespace cpark
+
+#endif  // CPARK_SAMPLE_RDD_H
+
+

--- a/include/sample_rdd.h
+++ b/include/sample_rdd.h
@@ -8,6 +8,15 @@
 #include "utils.h"
 namespace cpark {
 
+/** @ingroup g_trans
+ *  @defgroup t_Sample Sample
+ *  This forms the Sample Transformation of our cpark library
+ *  @image html sample.drawio.png "SampleRdd diagram" width=50%
+ *  @image latex sample.drawio.png "SampleRdd diagram" width=10cm
+ *  @see SampleRdd
+ *  @see Sample
+ *  @{
+ */
 /**
  * An Rdd holding the sampled data from an old rdd by a specific sample fraction
  * @tparam R Type of the old Rdd.

--- a/include/zipped_rdd.h
+++ b/include/zipped_rdd.h
@@ -25,7 +25,8 @@ public:
     int cnt = 0;
     for (const concepts::Split auto& prev_split : prev1) {
       int i = 0;
-      std::function<std::pair<V1, V2>(const V1&)> func = [cnt,&prev2,&i](const V1& x)mutable{return std::make_pair(x, prev2[cnt][i++]);};
+      auto targeted_split = prev2[cnt].begin();
+      std::function<std::pair<V1, V2>(const V1&)> func = [cnt,targeted_split](const V1& x)mutable{return std::make_pair(x, *(targeted_split++));};
       auto zippedView = prev_split | std::views::transform(func);
       splits_.emplace_back(zippedView, prev_split);
       splits_.back().addDependency(prev_split);

--- a/include/zipped_rdd.h
+++ b/include/zipped_rdd.h
@@ -67,6 +67,8 @@ private:
                std::views::transform(std::declval<std::function<std::pair<V1, V2>(const V1&)>>()));
   std::vector<ViewSplit<ZippedViewType>> splits_{};
 };
+/** @} */ // end of t_Zip
+
 }  // namespace cpark
 
 #endif  // CPARK_TRANSFORMED_RDD_H

--- a/include/zipped_rdd.h
+++ b/include/zipped_rdd.h
@@ -10,6 +10,14 @@
 
 namespace cpark {
 
+/** @ingroup g_trans
+ *  @defgroup t_Zip Zip
+ *  This forms the Zip Transformation of our cpark library
+ *  @image html zip.drawio.png "ZippedRdd diagram" width=50%
+ *  @image latex zip.drawio.png "ZippedRdd diagram" width=10cm
+ *  @see ZippedRdd
+ *  @{
+ */
 /**
  * An Rdd holding the zipped data from two old rdds
  * @tparam R1 Type of the first old Rdd.

--- a/include/zipped_rdd.h
+++ b/include/zipped_rdd.h
@@ -1,0 +1,53 @@
+#ifndef CPARK_ZIPPED_RDD_H
+#define CPARK_ZIPPED_RDD_H
+
+#include <vector>
+#include <ranges>
+#include <iterator>
+
+#include "base_rdd.h"
+#include "utils.h"
+
+namespace cpark {
+
+template <concepts::Rdd R1, concepts::Rdd R2>
+class ZippedRdd : public BaseRdd<ZippedRdd<R1, R2>> {
+public:
+  using Base = BaseRdd<ZippedRdd<R1, R2>>;
+  friend Base;
+
+  using V1 = utils::RddElementType<R1>;
+  using V2 = utils::RddElementType<R2>;
+
+  constexpr ZippedRdd(const R1& prev1, const R2& prev2) : Base{prev1, false} {
+    static_assert(concepts::Rdd<ZippedRdd<R1, R2>>,
+                  "Instance of ZippedRdd does not satisfy Rdd concept.");
+    int cnt = 0;
+    for (const concepts::Split auto& prev_split : prev1) {
+      int i = 0;
+      std::function<std::pair<V1, V2>(const V1&)> func = [cnt,&prev2,&i](const V1& x)mutable{return std::make_pair(x, prev2[cnt][i++]);};
+      auto zippedView = prev_split | std::views::transform(func);
+      splits_.emplace_back(zippedView, prev_split);
+      splits_.back().addDependency(prev_split);
+      cnt++;
+    }
+  }
+
+  constexpr ZippedRdd(const ZippedRdd&) = default;
+  ZippedRdd& operator=(const ZippedRdd&) = default;
+
+private:
+  constexpr auto beginImpl() const { return std::ranges::begin(splits_); }
+
+  constexpr auto endImpl() const { return std::ranges::end(splits_); }
+
+private:
+    using ZippedViewType = decltype( std::declval<R1>().front() | std::views::transform(std::declval<std::function<std::pair<V1, V2>(const V1&)>>()));
+  
+  //std::function<std::pair<V1, V2>(const V1&)>;
+  //using ZippedViewType = std::ranges::range_value_t<R1>;
+  std::vector<ViewSplit<ZippedViewType>> splits_{};
+};
+}
+
+#endif // CPARK_TRANSFORMED_RDD_H

--- a/tests/base_rdd_test.cpp
+++ b/tests/base_rdd_test.cpp
@@ -86,9 +86,9 @@ TEST_F(BaseRddTest, SplitBasicOperations) {
   EXPECT_EQ(*split.begin(), split.front());
   EXPECT_EQ(split.begin() + split.size(), split.end());
 
-  for (size_t i : std::views::iota(0, split.size())) {
-    EXPECT_EQ(split[i], test_original_data_[i]);
-  }
+  // for (size_t i : std::views::iota(0, split.size())) {
+  //   EXPECT_EQ(split[i], test_original_data_[i]);
+  // }
 }
 
 TEST_F(BaseRddTest, SplitConstructorsAndSpecialOperations) {

--- a/tests/base_rdd_test.cpp
+++ b/tests/base_rdd_test.cpp
@@ -86,9 +86,9 @@ TEST_F(BaseRddTest, SplitBasicOperations) {
   EXPECT_EQ(*split.begin(), split.front());
   EXPECT_EQ(split.begin() + split.size(), split.end());
 
-  // for (size_t i : std::views::iota(0, split.size())) {
-  //   EXPECT_EQ(split[i], test_original_data_[i]);
-  // }
+  for (size_t i : std::views::iota(0, split.size())) {
+    EXPECT_EQ(split[i], test_original_data_[i]);
+  }
 }
 
 TEST_F(BaseRddTest, SplitConstructorsAndSpecialOperations) {

--- a/tests/sample_rdd_test.cpp
+++ b/tests/sample_rdd_test.cpp
@@ -27,9 +27,6 @@ TEST(SampleRdd, SamplewithFraction0) {
   auto sample_rdd = SampleRdd(generator_rdd, 0);
   int size = 0;
   for (const cpark::concepts::Split auto& split : sample_rdd) {
-       EXPECT_TRUE(split.begin() == split.end());
-      size += 1;
-    }
+    EXPECT_TRUE(split.begin() == split.end());
   }
-  EXPECT_EQ(0, size);
 }

--- a/tests/sample_rdd_test.cpp
+++ b/tests/sample_rdd_test.cpp
@@ -27,7 +27,7 @@ TEST(SampleRdd, SamplewithFraction0) {
   auto sample_rdd = SampleRdd(generator_rdd, 0);
   int size = 0;
   for (const cpark::concepts::Split auto& split : sample_rdd) {
-    for (const auto& x : split) {
+       EXPECT_TRUE(split.begin() == split.end());
       size += 1;
     }
   }

--- a/tests/sample_rdd_test.cpp
+++ b/tests/sample_rdd_test.cpp
@@ -1,0 +1,35 @@
+#include "sample_rdd.h"
+#include "cpark.h"
+#include "generator_rdd.h"
+#include "gtest/gtest.h"
+
+using cpark::GeneratorRdd;
+using cpark::SampleRdd;
+
+TEST(SampleRdd, SamplewithFraction1) {
+  cpark::ExecutionContext default_context{};
+  auto generator_rdd = GeneratorRdd(
+      0, 1000 + 1, [](auto x) { return x; }, &default_context);
+  auto sample_rdd = SampleRdd(generator_rdd, 1);
+  int size = 0;
+  for (const cpark::concepts::Split auto& split : sample_rdd) {
+    for (const auto& x : split) {
+      size += 1;
+    }
+  }
+  EXPECT_EQ(1001, size);
+}
+
+TEST(SampleRdd, SamplewithFraction0) {
+  cpark::ExecutionContext default_context{};
+  auto generator_rdd = GeneratorRdd(
+      0, 1000 + 1, [](auto x) { return x; }, &default_context);
+  auto sample_rdd = SampleRdd(generator_rdd, 0);
+  int size = 0;
+  for (const cpark::concepts::Split auto& split : sample_rdd) {
+    for (const auto& x : split) {
+      size += 1;
+    }
+  }
+  EXPECT_EQ(0, size);
+}

--- a/tests/zipped_rdd_test.cpp
+++ b/tests/zipped_rdd_test.cpp
@@ -1,0 +1,26 @@
+#include "cpark.h"
+#include "generator_rdd.h"
+#include "zipped_rdd.h"
+#include "gtest/gtest.h"
+#include <typeinfo>
+
+using cpark::GeneratorRdd;
+using cpark::ZippedRdd;
+
+TEST(ZippedRdd, ZippedRddCorrectness) {
+  cpark::ExecutionContext default_context{};
+  auto generator_rdd_1 = GeneratorRdd(
+      0, 1000 + 1, [](auto x) { return x; }, &default_context);
+  auto generator_rdd_2 = GeneratorRdd(
+      0, 1000 + 1, [](auto x) { return x; }, &default_context);
+  auto zipped_rdd = ZippedRdd(generator_rdd_1,generator_rdd_2);
+  int size = 0;
+  for (const cpark::concepts::Split auto& split : zipped_rdd) {
+    for (const auto& x : split) {
+      size += 1;
+    }
+  }
+  EXPECT_EQ(1001, size);
+  EXPECT_EQ(typeid(decltype(zipped_rdd[0].front())),typeid(std::tuple<int,int>));
+}
+

--- a/tests/zipped_rdd_test.cpp
+++ b/tests/zipped_rdd_test.cpp
@@ -1,8 +1,8 @@
+#include "zipped_rdd.h"
+#include <typeinfo>
 #include "cpark.h"
 #include "generator_rdd.h"
-#include "zipped_rdd.h"
 #include "gtest/gtest.h"
-#include <typeinfo>
 
 using cpark::GeneratorRdd;
 using cpark::ZippedRdd;
@@ -13,7 +13,7 @@ TEST(ZippedRdd, ZippedRddCorrectness) {
       0, 1000 + 1, [](auto x) { return x; }, &default_context);
   auto generator_rdd_2 = GeneratorRdd(
       0, 1000 + 1, [](auto x) { return x; }, &default_context);
-  auto zipped_rdd = ZippedRdd(generator_rdd_1,generator_rdd_2);
+  auto zipped_rdd = ZippedRdd(generator_rdd_1, generator_rdd_2);
   int size = 0;
   for (const cpark::concepts::Split auto& split : zipped_rdd) {
     for (const auto& x : split) {
@@ -21,6 +21,5 @@ TEST(ZippedRdd, ZippedRddCorrectness) {
     }
   }
   EXPECT_EQ(1001, size);
-  EXPECT_EQ(typeid(decltype(zipped_rdd[0].front())),typeid(std::tuple<int,int>));
+  EXPECT_EQ(typeid(decltype(zipped_rdd[0].front())), typeid(std::pair<int, int>));
 }
-


### PR DESCRIPTION
Files modified:
* examples/filter_even.cpp: Added usage examples of Sample operation.
* examples/simple.cpp: Added a usage eample of Zip operation.
* include/filter_rdd.h: Included ramdom header for the support of Sample operation.

Files added:
* include/sample_rdd.h: Sample operation. This operation is based on FilterView by passing random boolean function as a param to FilterView.
* include/zipped_rdd.h: Zip operation. No pipeline is implemented for the Zip operation since both params are Rdd, and using pipeline with one Rdd to be function param is a little bit weird.
* tests/sample_rdd_test.cpp: Google test for Sample.
* tests/zipped_rdd_test.cpp: Goole test for Zip.